### PR TITLE
Remove S. mansoni

### DIFF
--- a/src/mapping.js
+++ b/src/mapping.js
@@ -52,7 +52,7 @@ const mapping = {
     "£": [`aspergillus`, `aspergillus fumigatus`],
     "$": [`bee`],
     "b": [`bug`],
-    "W": [`c elegans`, `caenorhabditis elegans`, `schistosoma mansoni`],
+    "W": [`c elegans`, `caenorhabditis elegans`],
     "2": [`diatom`],
     "L": [`ecoli`, `escherichia coli`],
     "F": [`fly`, `drosophila melanogaster`],


### PR DESCRIPTION
It looks very different from C. elegans - they live in pairs and also, in people's blood vessels - showing it as a generic worm doesn't really work.

There's no good picture in the fonts for it - we could ask I guess - but until then, maybe remove it?